### PR TITLE
Removing === to prevent error

### DIFF
--- a/saas_backup/__openerp__.py
+++ b/saas_backup/__openerp__.py
@@ -29,7 +29,6 @@
     'website': 'https://github.com/YannickB',
     'description': """
     SaaS Backup
-    =================
     """,
     'demo': [],
     'data': ['saas_backup_data.xml'],


### PR DESCRIPTION
Hey Yannick 
I'd suggest to remove all those === since they will break the module logic. If you now go to settings > modules search for the module and open it (to update it for example) it will throw the following error:

File "/usr/lib/python2.7/dist-packages/docutils/utils/**init**.py", line 193, in system_message
    raise SystemMessage(msg, level)
SystemMessage: <string>:3: (SEVERE/4) Unexpected section title.

When you remove the === (that actually have no use other then cosmetic) the module will no longer throw up this error.
Note: you might want to do this for all the modules.
